### PR TITLE
LOG-2: Update logger to conditionally setup a reporting stream

### DIFF
--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -83,6 +83,8 @@ func NewLogger(config *Config) (*Logger, error) {
 			return monitoringCore
 		}))
 
+		l.closers = append(l.closers, monitorCloser)
+
 		// Only build a Kinesis stream for reporting if the name of the stream was supplied
 		if len(c.KinesisStreamReporting) > 0 {
 			reportingCore, reportCloser, err := buildReportingCore(
@@ -99,10 +101,8 @@ func NewLogger(config *Config) (*Logger, error) {
 				return reportingCore
 			}))
 
-			l.closers = append(l.closers, reportCloser, monitorCloser)
+			l.closers = append(l.closers, reportCloser)
 		}
-
-		l.closers = append(l.closers, monitorCloser)
 	}
 
 	return &l, nil


### PR DESCRIPTION
### About
The `logging` package has been updated to conditionally setup a reporting stream only when a non-empty value is supplied for the reporting Kinesis Firehose stream. This avoid errors from occurring when the `logging` package is only used for monitoring.

## To Do
Right now the only way to test the `logging` package is to use it as a dependency in some other project. It would be nice if the `logging` package was updated to make it easier to unit test or if some sort of integration tests were added for the package.