### PR TITLE
LOG-4: Remove duplicate outputs from logging package

### DIFF
--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -53,8 +53,8 @@ func NewLogger(config *Config) (*Logger, error) {
 	}
 
 	zapConfig.Encoding = "json"
-	zapConfig.OutputPaths = []string{"stdout", "stderr"}
-	zapConfig.ErrorOutputPaths = []string{"stdout", "stderr"}
+	zapConfig.OutputPaths = []string{"stdout"}
+	zapConfig.ErrorOutputPaths = []string{"stderr"}
 	zapConfig.Level.SetLevel(zapcore.Level(c.LogLevel))
 	// caller skip makes the caller appear as the line of code where this package is called,
 	// instead of where zap is called in this package


### PR DESCRIPTION
### About
This pull request removes duplicate outputs from the `logging` package. Before this change, the `logging` package would sent standard outputs and standard errors to `stdout` and `stderr`. This resulted in a duplication in messages since both `stdout` and `stderr` are collected.

### To Do
Right now the only way to test the logging package is to use it as a dependency in some other project. It would be nice if the logging package was updated to make it easier to unit test or if some sort of integration tests were added for the package.