### PR TITLE
PLFM-315: Fix IsNil()

### DIFF
--- a/pkg/uuid/uuid.go
+++ b/pkg/uuid/uuid.go
@@ -3,7 +3,6 @@ package uuid
 import (
 	"github.com/caring/go-packages/pkg/errors"
 	goouid "github.com/google/uuid"
-	"reflect"
 )
 
 type UUID struct {
@@ -73,10 +72,7 @@ func ParseBytes(b []byte) (UUID, error) {
 }
 
 func (uuid UUID) IsNil() bool {
-	if reflect.ValueOf(uuid.UUID).IsNil() {
-		return true
-	}
-	return false
+	return uuid.UUID.ID() == 0
 }
 
 func (uuid UUID) String() string {

--- a/pkg/uuid/uuid_test.go
+++ b/pkg/uuid/uuid_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 	"unsafe"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type test struct {
@@ -226,6 +228,17 @@ func TestCoding(t *testing.T) {
 
 var asString = "f47ac10b-58cc-0372-8567-0e02b2c3d479"
 var asBytes = []byte(asString)
+
+func TestIsNil(t *testing.T) {
+	id := UUID{}
+	assert.True(t, id.IsNil())
+
+	id = MustParse("f47ac10b-58cc-0372-8567-0e02b2c3d479")
+	assert.False(t, id.IsNil())
+
+	id = New()
+	assert.False(t, id.IsNil())
+}
 
 func BenchmarkParse(b *testing.B) {
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
## About
This PR fixes a know issue with the IsNil() function in the `uuid` package that results in a panic. This fix closes #30 and resolves ticket PLFM-315.