### PR TITLE
PLFM-316: Add NullString() method

### DIFF
--- a/pkg/uuid/uuid.go
+++ b/pkg/uuid/uuid.go
@@ -1,6 +1,7 @@
 package uuid
 
 import (
+	"database/sql"
 	"github.com/caring/go-packages/pkg/errors"
 	goouid "github.com/google/uuid"
 )
@@ -76,7 +77,14 @@ func (uuid UUID) IsNil() bool {
 }
 
 func (uuid UUID) String() string {
-	return string(uuid.UUID.String())
+	return uuid.UUID.String()
+}
+
+func (uuid UUID) NullString() sql.NullString {
+	if uuid.IsNil() {
+		return sql.NullString{String: uuid.String(), Valid: false}
+	}
+	return sql.NullString{String: uuid.String(), Valid: true}
 }
 
 func (uuid UUID) URN() string {

--- a/pkg/uuid/uuid_test.go
+++ b/pkg/uuid/uuid_test.go
@@ -240,6 +240,16 @@ func TestIsNil(t *testing.T) {
 	assert.False(t, id.IsNil())
 }
 
+func TestNullString(t *testing.T) {
+	id := UUID{}
+	assert.True(t, id.IsNil())
+	assert.False(t, id.NullString().Valid)
+
+	id = MustParse("f47ac10b-58cc-0372-8567-0e02b2c3d479")
+	assert.False(t, id.IsNil())
+	assert.True(t, id.NullString().Valid)
+}
+
 func BenchmarkParse(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, err := Parse(asString)


### PR DESCRIPTION
### About
This PR addresses issue #31 back adding the method `NullString()` to the `uuid` package. This method is used to return a SQL null string for UUID values that are null instead of a zero value.