### PR TITLE
forgot to bump go.mod version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/caring/go-packages
+module github.com/caring/go-packages/v2
 
 go 1.13
 

--- a/pkg/pagination/graphql/models.go
+++ b/pkg/pagination/graphql/models.go
@@ -1,3 +1,4 @@
+package pagination
 
 // PageInfo represents params from a page response
 type PageInfo struct {


### PR DESCRIPTION
By rule, if your major version is above v0 or v1, your go.mod module path needs to require the major version