### PR TITLE
Fix a moved indirect dependency that caused go mod tidy errors on importers of this package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,17 @@ module github.com/caring/go-packages/v2
 go 1.13
 
 require (
+	github.com/HdrHistogram/hdrhistogram-go v1.0.1 // indirect
 	github.com/aws/aws-sdk-go v1.31.5
-	github.com/golang/protobuf v1.4.0
+	github.com/golang/protobuf v1.4.3
 	github.com/google/uuid v1.1.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0
-	github.com/opentracing/opentracing-go v1.1.0
-	github.com/stretchr/testify v1.6.0
-	github.com/uber/jaeger-client-go v2.23.1+incompatible
-	github.com/uber/jaeger-lib v2.2.0+incompatible
+	github.com/opentracing/opentracing-go v1.2.0
+	github.com/prometheus/client_golang v1.9.0 // indirect
+	github.com/stretchr/testify v1.6.1
+	github.com/uber/jaeger-client-go v2.25.0+incompatible
+	github.com/uber/jaeger-lib v2.4.0+incompatible
+	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.5.0
 	go.uber.org/zap v1.15.0
 	google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55


### PR DESCRIPTION
When trying to run `go mod tidy` in the customers service I ran into the following issue

https://github.com/HdrHistogram/hdrhistogram-go/issues/30
https://github.com/jaegertracing/jaeger-lib/pull/82

Fix was to update jaeger to the fixed versions then run `go mod tidy` on this repo