### PR TITLE
Plfm 329 logger interface

### DIFF
--- a/pkg/logging/field.go
+++ b/pkg/logging/field.go
@@ -2,9 +2,17 @@ package logging
 
 import "go.uber.org/zap"
 
+type DataField interface {
+	GetField() zap.Field
+}
+
 // Field is a typed and structured log entry string key and value pair
 type Field struct {
 	field zap.Field
+}
+
+func (f Field) GetField() zap.Field {
+	return f.field
 }
 
 // String constructs a field with a string value

--- a/pkg/logging/field.go
+++ b/pkg/logging/field.go
@@ -3,7 +3,7 @@ package logging
 import "go.uber.org/zap"
 
 type DataField interface {
-	GetField() zap.Field
+	getField() zap.Field
 }
 
 // Field is a typed and structured log entry string key and value pair
@@ -11,7 +11,7 @@ type Field struct {
 	field zap.Field
 }
 
-func (f Field) GetField() zap.Field {
+func (f Field) getField() zap.Field {
 	return f.field
 }
 

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -281,12 +281,12 @@ func (l *Logger) getZapFields(fields ...DataField) []zap.Field {
 
 	i := internalFieldcount
 	for _, f := range l.fields {
-		zapped[i] = f.GetField()
+		zapped[i] = f.getField()
 		i++
 	}
 
 	for _, f := range fields {
-		zapped[i] = f.GetField()
+		zapped[i] = f.getField()
 		i++
 	}
 

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -10,6 +10,23 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+type Logging interface {
+	GetInternalLogger() *zap.Logger
+	Sync() error
+	Close() error
+	NewChild(opts *FieldOpts, fields ...Field) *Logger
+	With(opts *FieldOpts, fields ...Field) *Logger
+	Debug(message string, additionalFields ...Field)
+	Report(message string, additionalFields ...Field)
+	Info(message string, additionalFields ...Field)
+	Warn(message string, additionalFields ...Field)
+	Error(message string, additionalFields ...Field)
+	Panic(message string, additionalFields ...Field)
+	DPanic(message string, additionalFields ...Field)
+	Fatal(message string, additionalFields ...Field)
+	getZapFields(fields ...Field) []zap.Field
+}
+
 // Logger provides fast, structured, type safe leveled logging. All log output methods are safe for concurrent use
 type Logger struct {
 	// The name of the service

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -73,7 +73,7 @@ func Test_LoggerSetInternalFields(t *testing.T) {
 	t.Run("Accumulates fields on existing ones", func(t *testing.T) {
 		s := String("one", "two")
 		l := &Logger{
-			fields: []Field{s},
+			fields: []DataField{s},
 		}
 
 		ss := String("three", "four")
@@ -86,7 +86,7 @@ func Test_LoggerSetInternalFields(t *testing.T) {
 
 	t.Run("Overwrites accumulated fields when the options require", func(t *testing.T) {
 		l := &Logger{
-			fields: []Field{String("one", "two")},
+			fields: []DataField{String("one", "two")},
 		}
 
 		ss := String("three", "four")
@@ -134,7 +134,7 @@ func Test_LoggerLogFatal(t *testing.T) {
 func Test_LoggerLeveledMethods(t *testing.T) {
 	withLogger(config, func(logger *Logger, logs *observer.ObservedLogs) {
 		tests := []struct {
-			method        func(string, ...Field)
+			method        func(string, ...DataField)
 			expectedLevel zapcore.Level
 		}{
 			{logger.Debug, zap.DebugLevel},

--- a/pkg/logging/middleware.go
+++ b/pkg/logging/middleware.go
@@ -10,7 +10,7 @@ import (
 // NewJaegerLogger returns a jaeger logging interface implementer that has been populated
 // with Loggers internal and accumulated fields as well as settings
 func (l *Logger) NewJaegerLogger() jaeger.Logger {
-	populatedL := l.monitorLogger.With(l.getZapFields()...)
+	populatedL := l.GetInternalLogger().With(l.getZapFields()...)
 	j := jaeger_zap.NewLogger(populatedL)
 
 	return j
@@ -19,7 +19,7 @@ func (l *Logger) NewJaegerLogger() jaeger.Logger {
 // NewJaegerLogger returns a jaeger logging interface implementer that has been populated
 // with Loggers internal and accumulated fields as well as settings
 func NewJaegerLogger(l Logging) jaeger.Logger {
-	populatedL := l.monitorLogger.With(l.getZapFields()...)
+	populatedL := l.GetInternalLogger().With(l.getZapFields()...)
 	j := jaeger_zap.NewLogger(populatedL)
 
 	return j
@@ -28,13 +28,13 @@ func NewJaegerLogger(l Logging) jaeger.Logger {
 // NewGRPCUnaryServerInterceptor returns a gRPC unary interceptor that has been populated
 // with Loggers internal and accumulated fields as well as settings
 func (l *Logger) NewGRPCUnaryServerInterceptor() grpc.UnaryServerInterceptor {
-	populatedL := l.monitorLogger.With(l.getZapFields()...)
+	populatedL := l.GetInternalLogger().With(l.getZapFields()...)
 
 	return grpc_zap.UnaryServerInterceptor(populatedL)
 }
 
 func NewGRPCUnaryServerInterceptor(l Logging) grpc.UnaryServerInterceptor {
-	populatedL := l.monitorLogger.With(l.getZapFields()...)
+	populatedL := l.GetInternalLogger().With(l.getZapFields()...)
 
 	return grpc_zap.UnaryServerInterceptor(populatedL)
 }
@@ -42,13 +42,13 @@ func NewGRPCUnaryServerInterceptor(l Logging) grpc.UnaryServerInterceptor {
 // NewGRPCStreamServerInterceptor returns a gRPC stream interceptor that has been populated
 // with Loggers internal and accumulated fields as well as settings
 func (l *Logger) NewGRPCStreamServerInterceptor() grpc.StreamServerInterceptor {
-	populatedL := l.monitorLogger.With(l.getZapFields()...)
+	populatedL := l.GetInternalLogger().With(l.getZapFields()...)
 
 	return grpc_zap.StreamServerInterceptor(populatedL)
 }
 
 func NewGRPCStreamServerInterceptor(l Logging) grpc.StreamServerInterceptor {
-	populatedL := l.monitorLogger.With(l.getZapFields()...)
+	populatedL := l.GetInternalLogger().With(l.getZapFields()...)
 
 	return grpc_zap.StreamServerInterceptor(populatedL)
 }

--- a/pkg/logging/middleware.go
+++ b/pkg/logging/middleware.go
@@ -25,15 +25,6 @@ func NewJaegerLogger(l Logging) jaeger.Logger {
 	return j
 }
 
-// NewJaegerLogger returns a jaeger logging interface implementer that has been populated
-// with Loggers internal and accumulated fields as well as settings
-func NewJaegerLogger(l Logging) jaeger.Logger {
-	populatedL := l.monitorLogger.With(l.getZapFields()...)
-	j := jaeger_zap.NewLogger(populatedL)
-
-	return j
-}
-
 // NewGRPCUnaryServerInterceptor returns a gRPC unary interceptor that has been populated
 // with Loggers internal and accumulated fields as well as settings
 func (l *Logger) NewGRPCUnaryServerInterceptor() grpc.UnaryServerInterceptor {
@@ -48,12 +39,6 @@ func NewGRPCUnaryServerInterceptor(l Logging) grpc.UnaryServerInterceptor {
 	return grpc_zap.UnaryServerInterceptor(populatedL)
 }
 
-func NewGRPCUnaryServerInterceptor(l Logging) grpc.UnaryServerInterceptor {
-	populatedL := l.monitorLogger.With(l.getZapFields()...)
-
-	return grpc_zap.UnaryServerInterceptor(populatedL)
-}
-
 // NewGRPCStreamServerInterceptor returns a gRPC stream interceptor that has been populated
 // with Loggers internal and accumulated fields as well as settings
 func (l *Logger) NewGRPCStreamServerInterceptor() grpc.StreamServerInterceptor {
@@ -64,12 +49,6 @@ func (l *Logger) NewGRPCStreamServerInterceptor() grpc.StreamServerInterceptor {
 
 func NewGRPCStreamServerInterceptor(l Logging) grpc.StreamServerInterceptor {
 	populatedL := l.GetInternalLogger().With(l.getZapFields()...)
-
-	return grpc_zap.StreamServerInterceptor(populatedL)
-}
-
-func NewGRPCStreamServerInterceptor(l Logging) grpc.StreamServerInterceptor {
-	populatedL := l.monitorLogger.With(l.getZapFields()...)
 
 	return grpc_zap.StreamServerInterceptor(populatedL)
 }

--- a/pkg/logging/middleware.go
+++ b/pkg/logging/middleware.go
@@ -16,6 +16,15 @@ func (l *Logger) NewJaegerLogger() jaeger.Logger {
 	return j
 }
 
+// NewJaegerLogger returns a jaeger logging interface implementer that has been populated
+// with Loggers internal and accumulated fields as well as settings
+func NewJaegerLogger(l Logging) jaeger.Logger {
+	populatedL := l.monitorLogger.With(l.getZapFields()...)
+	j := jaeger_zap.NewLogger(populatedL)
+
+	return j
+}
+
 // NewGRPCUnaryServerInterceptor returns a gRPC unary interceptor that has been populated
 // with Loggers internal and accumulated fields as well as settings
 func (l *Logger) NewGRPCUnaryServerInterceptor() grpc.UnaryServerInterceptor {
@@ -24,9 +33,21 @@ func (l *Logger) NewGRPCUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return grpc_zap.UnaryServerInterceptor(populatedL)
 }
 
+func NewGRPCUnaryServerInterceptor(l Logging) grpc.UnaryServerInterceptor {
+	populatedL := l.monitorLogger.With(l.getZapFields()...)
+
+	return grpc_zap.UnaryServerInterceptor(populatedL)
+}
+
 // NewGRPCStreamServerInterceptor returns a gRPC stream interceptor that has been populated
 // with Loggers internal and accumulated fields as well as settings
 func (l *Logger) NewGRPCStreamServerInterceptor() grpc.StreamServerInterceptor {
+	populatedL := l.monitorLogger.With(l.getZapFields()...)
+
+	return grpc_zap.StreamServerInterceptor(populatedL)
+}
+
+func NewGRPCStreamServerInterceptor(l Logging) grpc.StreamServerInterceptor {
 	populatedL := l.monitorLogger.With(l.getZapFields()...)
 
 	return grpc_zap.StreamServerInterceptor(populatedL)

--- a/pkg/tracing/config.go
+++ b/pkg/tracing/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	// Or the source code for this sampler https://github.com/jaegertracing/jaeger-client-go/blob/master/sampler.go#L242
 	SampleRate float64
 	// The instance of our own logger to use for logging traces
-	Logger *logging.Logger
+	Logger logging.Logging
 	// key values pairs that will be included on all spans
 	GlobalTags map[string]string
 }

--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -3,6 +3,7 @@ package tracing
 import (
 	"io"
 
+	"github.com/caring/go-packages/v2/pkg/logging"
 	"github.com/opentracing/opentracing-go"
 	"github.com/uber/jaeger-client-go"
 	"github.com/uber/jaeger-lib/metrics/prometheus"
@@ -49,15 +50,15 @@ func NewTracer(config *Config) (*Tracer, error) {
 		// create composite logger to log to the logger and report to the
 		// remote server
 		t.reporter = jaeger.NewCompositeReporter(
-			jaeger.NewLoggingReporter(l.NewJaegerLogger()),
+			jaeger.NewLoggingReporter(logging.NewJaegerLogger(l)),
 			jaeger.NewRemoteReporter(transport,
 				jaeger.ReporterOptions.Metrics(metrics),
-				jaeger.ReporterOptions.Logger(l.NewJaegerLogger()),
+				jaeger.ReporterOptions.Logger(logging.NewJaegerLogger(l)),
 			),
 		)
 	} else {
 		// Simple, logging only reporter
-		t.reporter = jaeger.NewLoggingReporter(l.NewJaegerLogger())
+		t.reporter = jaeger.NewLoggingReporter(logging.NewJaegerLogger(l))
 	}
 
 	// create a sampler for the spans so that we don't report every single span which would be untenable


### PR DESCRIPTION
these are fixes that make it work basically... tested this by using the logging interface in the identity service, and it worked... though it did require me still updating all logging import paths to v2... but the interface only exists in v2....

this should just be a stopgap "fix and then we probably should move these cross-cutting packages into individual repos... like

gopgk-logging or something that makes it clear they're all go packages