### PR TITLE
fix: check for invalid port range returning nil

### DIFF
--- a/pkg/grpc_middleware/dialconn/builder.go
+++ b/pkg/grpc_middleware/dialconn/builder.go
@@ -143,8 +143,11 @@ func (b *ConnBuilder) SetConnInfo(dns, port string) error {
 	b.dns = &dns
 
 	i, err := strconv.ParseUint(port, 10, 32)
-	if err != nil || i < 0 || i > 65353 {
+	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("invalid port number: %s", port))
+	}
+	if i < 0 || i > 65535 {
+		return errors.Errorf("invalid port number: %s", port)
 	}
 	b.port = &port
 


### PR DESCRIPTION
- ports are valid from 0 to 65535. 
- If the port number is out of range the value of err is nil. wrapping a nil error returns nil so the check was silently failing.
